### PR TITLE
Implement Github Action for firmware build and Release Notes updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 version-template: '$MAJOR.$MINOR'
-name-template: 'v$RESOLVED_VERSION 🌈'
+name-template: 'v$RESOLVED_VERSION 🎉'
 tag-template: 'v$RESOLVED_VERSION'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+version-template: '$MAJOR.$MINOR'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'documentation'
+
+exclude-labels:
+  - 'skip-changelog'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  default: minor

--- a/.github/workflows/Platformio-ci.yaml
+++ b/.github/workflows/Platformio-ci.yaml
@@ -1,0 +1,71 @@
+name: PlatformIO CI
+
+on: [push]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Roast Meter BLE firmware
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-${{ hashfiles('platformio.ini') }}-pio
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Install Appolo3 Blue platform
+        run: pio platform install git+https://github.com/nigelb/platform-apollo3blue
+
+      - name: Update environment with Appolo3 framework
+        run: pio project init -e SparkFun_Thing_Plus_Artemis -O'platform_packages=framework-arduinoapollo3@https://github.com/sparkfun/Arduino_Apollo3#v2.2.2'
+
+      - name: Install Platformio Libraries
+        run: pio pkg install
+
+      - id: setTextVars
+        name: Set Environment varitables
+        run: |
+          COMMIT_HASH=$(echo ${{ github.sha }} | cut -c1-6)
+          echo "COMMIT_HASH=${COMMIT_HASH}" >> "$GITHUB_ENV"
+          # ?TAG
+          echo "GIT_TAG=$(git tag --points-at HEAD)" >> "$GITHUB_ENV"
+      
+      - name: Replace Version ID
+        id: update_build_versions
+        run: |
+          ${{ env.GIT_TAG && 'VERSION="$GIT_TAG\\\\r\\\\nGIT:$COMMIT_HASH"' || 'VERSION="GIT:$COMMIT_HASH"' }}
+          sed -i -E \
+              "s/^(\s+\-D\s?FIRMWARE_REVISION_STRING).+\$/\1='\"$VERSION\"'/" \
+              platformio.ini
+
+      - name: Build PlatformIO Project
+        run: pio run
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Firmware
+          path: .
+#          path: |
+#            .pio/build/SparkFun_Thing_Plus_Artemis/firmware.bin
+#
+  UploadAssets:
+    name: Upload Assets
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs:
+      - build
+    uses: ./.github/workflows/upload-release-assets.yaml

--- a/.github/workflows/Platformio-ci.yaml
+++ b/.github/workflows/Platformio-ci.yaml
@@ -10,6 +10,9 @@ jobs:
     name: Build Roast Meter BLE firmware
     runs-on: ubuntu-latest
 
+    env:
+      PIO_ENV: "SparkFun_Thing_Plus_Artemis"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +34,7 @@ jobs:
         run: pio platform install git+https://github.com/nigelb/platform-apollo3blue
 
       - name: Update environment with Appolo3 framework
-        run: pio project init -e SparkFun_Thing_Plus_Artemis -O'platform_packages=framework-arduinoapollo3@https://github.com/sparkfun/Arduino_Apollo3#v2.2.2'
+        run: pio project init -e ${{ env.PIO_ENV }} -O'platform_packages=framework-arduinoapollo3@https://github.com/sparkfun/Arduino_Apollo3#v2.2.2'
 
       - name: Install Platformio Libraries
         run: pio pkg install
@@ -53,14 +56,14 @@ jobs:
               platformio.ini
 
       - name: Build PlatformIO Project
-        run: pio run
+        run: pio run -e ${{ env.PIO_ENV }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Firmware
           path: |
-            .pio/build/SparkFun_Thing_Plus_Artemis/firmware.bin
+            .pio/build/${{ env.PIO_ENV }}/firmware.bin
 
   UploadAssets:
     name: Upload Assets

--- a/.github/workflows/Platformio-ci.yaml
+++ b/.github/workflows/Platformio-ci.yaml
@@ -59,10 +59,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Firmware
-          path: .
-#          path: |
-#            .pio/build/SparkFun_Thing_Plus_Artemis/firmware.bin
-#
+          path: |
+            .pio/build/SparkFun_Thing_Plus_Artemis/firmware.bin
+
   UploadAssets:
     name: Upload Assets
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,26 @@
+name: "Draft Release notes"
+
+# Controls when the action will run.
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_draft_release:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "dev" or "master"
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -1,0 +1,34 @@
+name: "Upload Release Assets"
+
+# Controls when the action will run.
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+
+jobs:
+  UploadAssets:
+    name: Upload Assets
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    env:
+      firmware_zip: 'Roast Meter BLE Firmware-${{ github.ref_name }}.zip'
+
+    steps:
+      - id: download
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - id: zip_firmware
+        run: zip -r -5 '${{ env.firmware_zip }}' .
+      
+      - id: upload_assets
+        name: Upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ env.firmare_zip }}
+          generate_release_notes: false

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
-      firmware_zip: 'Roast Meter BLE Firmware-${{ github.ref_name }}.zip'
+      firmware_name: 'Roast Meter BLE Firmware-${{ github.ref_name }}.bin'
 
     steps:
       - id: download
@@ -22,13 +22,13 @@ jobs:
         with:
           merge-multiple: true
 
-      - id: zip_firmware
-        run: zip -r -5 '${{ env.firmware_zip }}' .
+      - id: firmware_name
+        run: mv firmware.bin '${{ env.firmware_name }}'
       
       - id: upload_assets
         name: Upload assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ${{ env.firmware_zip }}
+            ${{ env.firmware_name }}
           generate_release_notes: false

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -30,5 +30,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ${{ env.firmare_zip }}
+            ${{ env.firmware_zip }}
           generate_release_notes: false

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,8 @@ lib_deps =
 	sparkfun/SparkFun Micro OLED Breakout@^1.3.3
 	sparkfun/SparkFun MAX3010x Pulse and Proximity Sensor Library@^1.1.2
 	arduino-libraries/ArduinoBLE@^1.3.4
+build_flags =
+    -D FIRMWARE_REVISION_STRING='"v0.1"'
 build_src_filter =
 	-<roast_meter.ino.cpp>
 	-<roast_meter.ino>

--- a/src/roast_meter_ble.cpp
+++ b/src/roast_meter_ble.cpp
@@ -7,7 +7,9 @@
 #include "MAX30105.h"
 
 // -- Constant Values --
+#ifndef FIRMWARE_REVISION_STRING
 #define FIRMWARE_REVISION_STRING "v0.1"
+#endif  //FIRMWARE_REVISION_STRING
 
 #define PIN_RESET 9
 #define DC_JUMPER 1
@@ -346,6 +348,7 @@ void displayStartUp() {
   oled.setFontType(1);
   oled.print("Roast  ");
   oled.print("Meter  ");
+  oled.setFontType(0);
   oled.print(FIRMWARE_REVISION_STRING);
   oled.display();
 


### PR DESCRIPTION
Implement GitHub actions to automatically build the BLE firmware and add it to the release assets on tagging.
Use GitHub actions to automatically generate release notes based on PRs history ([release drafter](https://github.com/release-drafter/release-drafter))

This should simplify installation for the end users, as you can use [Artemis Firmware Upload GUI](https://github.com/sparkfun/Artemis-Firmware-Upload-GUI?tab=readme-ov-file#sparkfun-artemis-uploader-app) to upload the firmware. 

A new firmware is built on any new push to the repo, and upon release + tagging the firmware is uploaded to the release notes. For example https://github.com/Adminiuga/roast-meter/releases 
Upon building, the commit hash and tag is used as a version string, to help positively identify the installed version on the device.

Let me know if you would like to split this PR into two different: one for firmware build and another for the release drafter.

I made an assumption, the BLE firmware is the recommended firmware, as it allows calibration without the need for firmware rebuild. If needed, I can add a serial & eeprom interface to the original `roast_meter.ino` firmware, let me know.
